### PR TITLE
fix qt plugin load

### DIFF
--- a/zoomrec.py
+++ b/zoomrec.py
@@ -527,15 +527,19 @@ def join(meet_id, meet_pw, duration, user, description):
 
     join_by_url = meet_id.startswith('https://') or meet_id.startswith('http://')
 
+    env = os.environ.copy()
+    del env["LD_LIBRARY_PATH"]
+    del env["QT_QPA_PLATFORM_PLUGIN_PATH"]
+
     if not join_by_url:
         # Start Zoom
         zoom = subprocess.Popen("zoom", stdout=subprocess.PIPE,
-                                shell=True, preexec_fn=os.setsid)
+                                shell=True, preexec_fn=os.setsid, env=env)
         img_name = 'join_meeting.png'
     else:
         logging.info("Starting zoom with url")
         zoom = subprocess.Popen(f'zoom --url="{meet_id}"', stdout=subprocess.PIPE,
-                                shell=True, preexec_fn=os.setsid)
+                                shell=True, preexec_fn=os.setsid, env=env)
         img_name = 'join.png'
     
     # Wait while zoom process is there


### PR DESCRIPTION
zoom does not start at all for me. 
error:
```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "/usr/local/lib/python3.12/dist-packages/cv2/qt/plugins" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: xcb, eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx.
```

This fixes it.

PS: Please enable issues for this repo, as during testing I found a few other issues I would like to discuss on how to best proceed.  (f.e. starting "zoom --url" seems to be ignored by newer zoom versions. so this script gets stuck).
So I hope we can collaborate to get this tool fixed and not duplicate work.